### PR TITLE
Setting atto_aic\\ai::format_response() as static

### DIFF
--- a/classes/ai.php
+++ b/classes/ai.php
@@ -91,7 +91,7 @@ class ai {
      * @param int $choice
      * @return string $html
      */
-    private function format_response($response,  $choice) {
+    private static function format_response($response,  $choice) {
         $tab = [];
         $content = [];
         for ($i = 1; $i <= $choice; $i++) {


### PR DESCRIPTION
Moodle Version = 4.3.3+ (Build: 20240308)
Atto AIC Version = 1.2

Hi,
with a fresh install, right after setting params and API KEY, the call to ajax.php when requesting content form the modal returns:

Non-static method atto_aic\\ai::format_response() cannot be called statically
Setting the method format_response to static does fix the issue